### PR TITLE
Enabled persistence for Firebase database & some other fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion '24.0.3'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.1'
 
     defaultConfig {
         applicationId "com.example.androidthings.doorbell"
         minSdkVersion 24
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -25,8 +25,8 @@ android {
 
 dependencies {
     provided 'com.google.android.things:androidthings:0.1-devpreview'
-    compile 'com.google.firebase:firebase-core:9.4.0'
-    compile 'com.google.firebase:firebase-database:9.4.0'
+    compile "com.google.firebase:firebase-core:${firebaseVersion}"
+    compile "com.google.firebase:firebase-database:${firebaseVersion}"
     compile 'com.google.android.things.contrib:driver-button:0.1'
 
     compile 'com.google.apis:google-api-services-vision:v1-rev22-1.22.0'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.google.gms:google-services:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -21,4 +21,9 @@ allprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+ext {
+    firebaseVersion = '10.0.1'
+    supportLibraryVersion = '25.1.0'
 }

--- a/companionApp/build.gradle
+++ b/companionApp/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion '24.0.3'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.1'
 
     defaultConfig {
         applicationId "com.example.androidthings.doorbell"
-        minSdkVersion 24
-        targetSdkVersion 24
+        minSdkVersion 21
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -21,11 +21,11 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.firebase:firebase-core:9.4.0'
-    compile 'com.google.firebase:firebase-database:9.4.0'
-    compile 'com.firebaseui:firebase-ui-database:0.5.3'
-    compile 'com.android.support:recyclerview-v7:25.0.1'
-    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile "com.google.firebase:firebase-core:${firebaseVersion}"
+    compile "com.google.firebase:firebase-database:${firebaseVersion}"
+    compile 'com.firebaseui:firebase-ui-database:1.0.1'
+    compile "com.android.support:recyclerview-v7:${supportLibraryVersion}"
+    compile "com.android.support:appcompat-v7:${supportLibraryVersion}"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/companionApp/src/main/AndroidManifest.xml
+++ b/companionApp/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.example.androidthings.doorbell">
+    package="com.example.androidthings.doorbell">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/companionApp/src/main/AndroidManifest.xml
+++ b/companionApp/src/main/AndroidManifest.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.androidthings.doorbell">
+          package="com.example.androidthings.doorbell">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <application android:allowBackup="true" android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name" android:supportsRtl="true" android:theme="@style/AppTheme">
+    <application
+        android:name=".DoorbellApplication"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
 
         <activity android:name=".MainActivity">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
     </application>

--- a/companionApp/src/main/java/com/example/androidthings/doorbell/DoorbellApplication.java
+++ b/companionApp/src/main/java/com/example/androidthings/doorbell/DoorbellApplication.java
@@ -1,0 +1,13 @@
+package com.example.androidthings.doorbell;
+
+import android.app.Application;
+
+import com.google.firebase.database.FirebaseDatabase;
+
+public class DoorbellApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        FirebaseDatabase.getInstance().setPersistenceEnabled(true);
+    }
+}

--- a/companionApp/src/main/java/com/example/androidthings/doorbell/DoorbellEntryAdapter.java
+++ b/companionApp/src/main/java/com/example/androidthings/doorbell/DoorbellEntryAdapter.java
@@ -50,9 +50,9 @@ public class DoorbellEntryAdapter extends FirebaseRecyclerAdapter<DoorbellEntry,
         public DoorbellEntryViewHolder(View itemView) {
             super(itemView);
 
-            this.image = (ImageView) itemView.findViewById(R.id.imageView1);
-            this.time = (TextView) itemView.findViewById(R.id.textView1);
-            this.metadata = (TextView) itemView.findViewById(R.id.textView2);
+            this.image = (ImageView) itemView.findViewById(R.id.imageViewCapture);
+            this.time = (TextView) itemView.findViewById(R.id.textViewTimestamp);
+            this.metadata = (TextView) itemView.findViewById(R.id.textViewMetadata);
         }
     }
 

--- a/companionApp/src/main/java/com/example/androidthings/doorbell/MainActivity.java
+++ b/companionApp/src/main/java/com/example/androidthings/doorbell/MainActivity.java
@@ -19,6 +19,7 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
@@ -35,23 +36,14 @@ public class MainActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-
         mRecyclerView = (RecyclerView) findViewById(R.id.doorbellView);
         // Show most recent items at the top
-        LinearLayoutManager layoutManager =
-                new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, true);
+        LinearLayoutManager layoutManager = new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, true);
         mRecyclerView.setLayoutManager(layoutManager);
 
         // Reference for doorbell events from embedded device
         mDatabaseRef = FirebaseDatabase.getInstance().getReference().child("logs");
-    }
-
-    @Override
-    public void onStart() {
-        super.onStart();
-
-        mAdapter = new DoorbellEntryAdapter(this, mDatabaseRef);
-        mRecyclerView.setAdapter(mAdapter);
+        mAdapter = new DoorbellEntryAdapter(this, mDatabaseRef.getRef());
 
         // Make sure new events are visible
         mAdapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
@@ -60,17 +52,18 @@ public class MainActivity extends Activity {
                 mRecyclerView.smoothScrollToPosition(mAdapter.getItemCount());
             }
         });
+        mRecyclerView.setHasFixedSize(true);
+        mRecyclerView.setAdapter(mAdapter);
     }
 
-    @Override
-    public void onStop() {
-        super.onStop();
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
         // Tear down Firebase listeners in adapter
         if (mAdapter != null) {
             mAdapter.cleanup();
             mAdapter = null;
         }
     }
-
 }

--- a/companionApp/src/main/res/layout/doorbell_entry.xml
+++ b/companionApp/src/main/res/layout/doorbell_entry.xml
@@ -10,7 +10,7 @@
     <ImageView
         android:layout_width="220dp"
         android:layout_height="match_parent"
-        android:id="@+id/imageView1" />
+        android:id="@+id/imageViewCapture" />
 
     <LinearLayout
         android:orientation="vertical"
@@ -22,11 +22,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textStyle="bold"
-            android:id="@+id/textView1" />
+            android:id="@+id/textViewTimestamp" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/textView2" />
+            android:id="@+id/textViewMetadata" />
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Hi there, 
Thanks so much for this fun example of Android Things! I've made some improvements to the companion app, please see the pull request if you would like to merge the changes. 

Changes:
- Enabled persistence for Firebase database to speed up the loading of
the data on the client side (initial loading seems slow still but this will speed up further requests), I've also moved the initialization of the adapter into onCreate and onDestroy as it was reloading the data every time the app paused for a bit, this should also improve the performance a bit. 
- Updated version numbers of firebase dependencies from 9.4.0 to 10.0.1
- Made the companion app target minSdkVersion 21 as there was nothing stopping this from working on lower device levels.
- Code cleanup of doorbell_entry.xml to use better naming for Views.

Let me know if there is anything wrong with the contribution. 
